### PR TITLE
fix(proxymanager.js): Add missing parameters in create

### DIFF
--- a/src/io/protocols/ProxyManager.js
+++ b/src/io/protocols/ProxyManager.js
@@ -1,8 +1,20 @@
 /* eslint-disable arrow-body-style */
 export default function createMethods(session) {
   return {
-    create: (functionName, parentId = '0') => {
-      return session.call('pv.proxy.manager.create', [functionName, parentId]);
+    create: (
+      functionName,
+      parentId = '0',
+      initialValues = {},
+      skipDomain = false,
+      subProxyValues = {}
+    ) => {
+      return session.call('pv.proxy.manager.create', [
+        functionName,
+        parentId,
+        initialValues,
+        skipDomain,
+        subProxyValues,
+      ]);
     },
     open: (relativePath) => {
       return session.call('pv.proxy.manager.create.reader', [relativePath]);


### PR DESCRIPTION
Add parentId, initialValues, skipDomain and subProxyValues to ProxyManager.create. The server would not receive these values when creating a source or filter.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run lint` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

The server would not receive these values when creating a source or filter.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API.
-->

Add parentId, initialValues, skipDomain and subProxyValues to ProxyManager.create.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Bug is fixed!

